### PR TITLE
Fixes `Uncaught TypeError: undefined is not a function`, caused by the c...

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -31,7 +31,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     var bsDateTimePickerFn = bsDateTimePicker.data("DateTimePicker");
 
     this.set('bsDateTimePicker', bsDateTimePickerFn);
-    bsDateTimePickerFn.setDate(self.get("date"));
+    bsDateTimePickerFn.date(self.get("date"));
 
     bsDateTimePicker.on("dp.change", function(ev) {
       if(Ember.isNone(ev.date)) {
@@ -87,7 +87,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   }.observes("enabledDates"),
 
   _dateObserver: function() {
-    this.get("bsDateTimePicker").setDate(this.get('date'));
+    this.get("bsDateTimePicker").date(this.get('date'));
   }.observes("date"),
 
   _destroyDatepicker: function() {
@@ -116,4 +116,3 @@ bsDateTimePickerComponent.reopen(newClassConfig);
 
 
 export default bsDateTimePickerComponent;
-


### PR DESCRIPTION
...hange in v4 of bootstrap-datetimepicker:

```
set/getDate() is now replaced with an overloaded date() function. Use it without a parameter to get the currently set date or with a parameter to set the date.
```
http://eonasdan.github.io/bootstrap-datetimepicker/Version%204%20Changelog/

Fixes #6

Signed-off-by: Tommaso Visconti <tommaso.visconti@gmail.com>