### PR TITLE
Add the missing woff2 font for bootstrap, fixes a 404 font file not found error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
     	app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.svg'), { destDir: '/fonts' });
     	app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });
     	app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff'), { destDir: '/fonts' });
+      app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff2'), { destDir: '/fonts'});
     }
 
 


### PR DESCRIPTION
Add missing font resource for the Ember component's index page.