### PR TITLE
Add the ability to override the form-group-addon's child span class.

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -18,6 +18,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   maxDate: datetimepickerDefaultConfig["maxDate"],
   disabledDates:[],
   enabledDates:[],
+  dateIcon: "glyphicon glyphicon-calendar",
 
   disabled:false,
   open: false,
@@ -124,7 +125,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
 });
 
 
-var computedProps = ["minDate","maxDate","disabledDates","enabledDates"];
+var computedProps = ["minDate","maxDate","disabledDates","enabledDates","dateIcon"];
 var newClassConfig = {};
 for(var i=0; i<isDatetimepickerConfigKeys.length; i++) {
   if(!computedProps.contains(isDatetimepickerConfigKeys[i])) {

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,6 +1,6 @@
 <div class="datetimepicker input-group date">
   {{view textFieldClass classNames="form-control" disabled=disabled name=textFieldName}}
-	<span class="input-group-addon">
-		<span class="glyphicon glyphicon-calendar"></span>
- 	</span>
+  <span class="input-group-addon">
+    <span {{bind-attr class="dateIcon"}}></span>
+  </span>
 </div>

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -11,6 +11,8 @@
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/dummy.css">
+    <!-- Added Font-Awesome via CDN, instead of a bower dependency -->
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
     {{content-for 'head-footer'}}
   </head>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -6,6 +6,7 @@
           <li><a href="#example2">Init config</a></li>
           <li><a href="#example3">Min/Max date</a></li>
           <!-- li><a href="#example4">En/Disabled Dates</a></li -->
+          <li><a href="#example5">Font-Awesome Icons</a></li>
       </ul>
     </div>
   </div>
@@ -122,6 +123,29 @@
       </div>
     </div>
 
+
+    <div id="example5">
+      <a name="example5"></a>
+      <h3>Use Font-Awesome icons</h3>
+
+      <div>
+        <form class="form" role="form">
+          <div class="form-group">
+            <label>Font-Awesome</label>
+            {{bs-datetimepicker date=date2 dateIcon="fa fa-calendar" icons=faicons}}
+          </div>
+        </form>
+        <h5>Code</h5>
+        <p>
+          <pre>&lt;form class=&quot;form&quot; role=&quot;form&quot;&gt;
+&lt;div class=&quot;form-group&quot;&gt;
+  &lt;label&gt;Font-Awesome&lt;/label&gt;
+  \{{bs-datetimepicker date=date2 dateIcon="fa fa-calendar" icons=faicons}}
+&lt;/div&gt;
+          </pre>
+        </p>
+      </div>
+    </div>
 
   </div>
 </div>


### PR DESCRIPTION
Add the ability to customize the icon shown in the form-group-addon:

```html
{{bs-datetimepicker date=date2 dateIcon="fa fa-calendar" icons=faicons}}
```

The **icons** property is passed on to **eonasdan-bootstrap-datetimepicker** where **faicons** may be configured in the template's controller or by a mixin.

[Example mixin]
```javascript
import Ember from 'ember';

export default Ember.Mixin.create({
  faicons: {
    time: 'fa fa-clock-o',
    date: 'fa fa-calendar',
    up:   'fa fa-chevron-up',
    down: 'fa fa-chevron-down'
  }
});
```