### PR TITLE
Prevent update of date if it didn't changed

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -42,7 +42,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     bsDateTimePicker.on("dp.change", function(ev) {
       if(Ember.isNone(ev.date)) {
         self.set("date", undefined);
-      } else {
+      } else if (!ev.date.isSame(self.get('date'))) {
         if(self.forceDateOutput) {
           self.set("date", ev.date.toDate());
         } else {


### PR DESCRIPTION
The "dp.change" event is triggered on init, while the date didn't changed.

This issue comes when you bound the date to a model property. When the first "dp.change" event is called on init, the property is updated on the model and the isDirty property of the model becomes 'true'... whereas the value didn't changed.

This fix prevents that issue by checking if date value really changed.