### PR TITLE
Add icon for time only input

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -18,7 +18,15 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   maxDate: datetimepickerDefaultConfig["maxDate"],
   disabledDates:[],
   enabledDates:[],
-  dateIcon: "glyphicon glyphicon-calendar",
+
+  //Icon displayed in input addon
+  addonIcon: function() {
+    if (!this.get('format') || /(M|D|d|W|w|G|g|Y|E|e)/.test(this.get('format'))) {
+      return this.get('icons.date');
+    } else {
+      return this.get('icons.time');
+    }
+  }.property('format'),
 
   disabled:false,
   open: false,
@@ -125,7 +133,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
 });
 
 
-var computedProps = ["minDate","maxDate","disabledDates","enabledDates","dateIcon"];
+var computedProps = ["minDate","maxDate","disabledDates","enabledDates"];
 var newClassConfig = {};
 for(var i=0; i<isDatetimepickerConfigKeys.length; i++) {
   if(!computedProps.contains(isDatetimepickerConfigKeys[i])) {

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,6 +1,6 @@
 <div class="datetimepicker input-group date">
   {{view textFieldClass classNames="form-control" disabled=disabled name=textFieldName}}
   <span class="input-group-addon">
-    <span {{bind-attr class="dateIcon"}}></span>
+    <span {{bind-attr class="addonIcon"}}></span>
   </span>
 </div>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  faicons: {
+    time: 'fa fa-clock-o',
+    date: 'fa fa-calendar',
+    up:   'fa fa-chevron-up',
+    down: 'fa fa-chevron-down',
+    previous: 'fa fa-chevron-left',
+    next: 'fa fa-chevron-right',
+    today: 'fa fa-crosshairs',
+    clear: 'fa fa-trash'
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,0 @@
-<h2 id="title">Welcome to Ember.js</h2>
-
-{{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -140,7 +140,7 @@
           <pre>&lt;form class=&quot;form&quot; role=&quot;form&quot;&gt;
 &lt;div class=&quot;form-group&quot;&gt;
   &lt;label&gt;Font-Awesome&lt;/label&gt;
-  \{{bs-datetimepicker date=date2 dateIcon="fa fa-calendar" icons=faicons}}
+  \{{bs-datetimepicker date=date2 icons=faicons}}
 &lt;/div&gt;
           </pre>
         </p>
@@ -149,4 +149,3 @@
 
   </div>
 </div>
-


### PR DESCRIPTION
Hi,

Is it possible to add this feature?

When the component doesn't pick date, the addon icon is changed to a clock.

It enables also a more simple way to set font-awesome icons.