### PR TITLE
install same version of bootstrap-datetimepicker as in bower.json

### DIFF
--- a/blueprints/ember-bootstrap-datetimepicker/index.js
+++ b/blueprints/ember-bootstrap-datetimepicker/index.js
@@ -4,7 +4,7 @@ module.exports = {
   afterInstall: function() {
     var that = this;
 
-    return this.addBowerPackageToProject('eonasdan-bootstrap-datetimepicker').then(function() {
+    return this.addBowerPackageToProject('eonasdan-bootstrap-datetimepicker', '~4.7.14').then(function() {
         return that.addBowerPackageToProject('moment').then(function() {
           return that.addBowerPackageToProject('ember-cli-moment-shim');
       });


### PR DESCRIPTION
I was having the issue described in #33. The problem was setting from a valid date to undefined.
After a lot of trouble, I found out that I was using a more recent version of `eonasdan-bootstrap-datetimepicker`. There were other issues as well.

This PR makes sure that users get the right version. I think there are ways to dynamically link the version value with the one in bower.json file, to avoid this in the future.

When we bump the version in this project's bower dependencies, we should also bump them in the blueprints, after we make sure everything works fine.

When we do that bumping, we already know that setting from a valid date to undefined **will** fail. 

Fixes #33 