### PR TITLE
Fix Ember.keys and template deprecations, cleaning

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -1,30 +1,29 @@
-  
 import Ember from 'ember';
 import DateTimePickerTextFieldMixin from 'ember-bootstrap-datetimepicker/mixins/datetimepicker_textfield';
 
 var computed = Ember.computed;
 var datetimepickerDefaultConfig = Ember.$.fn.datetimepicker.defaults;
-var isDatetimepickerConfigKeys = Ember.keys(datetimepickerDefaultConfig);
+var isDatetimepickerConfigKeys = Object.keys(datetimepickerDefaultConfig);
 
 var bsDateTimePickerComponent = Ember.Component.extend({
-  concatenatedProperties: ["textFieldClassNames"],
-  classNames: ["date"],
-  classNameBindings: ["inputGroupClass"],
+  concatenatedProperties: ['textFieldClassNames'],
+  classNames: ['date'],
+  classNameBindings: ['inputGroupClass'],
   textFieldClass: Ember.TextField.extend(DateTimePickerTextFieldMixin),
-  textFieldClassNames: ["form-control"],
-  textFieldName: computed.alias("elementId"),
-  textFieldOptions:null,
+  textFieldClassNames: ['form-control'],
+  textFieldName: computed.alias('elementId'),
+  textFieldOptions: null,
   date: null,
   bsDateTimePicker: null,
 
-  //computed options
-  minDate: datetimepickerDefaultConfig["minDate"],
-  maxDate: datetimepickerDefaultConfig["maxDate"],
-  disabledDates:[],
-  enabledDates:[],
-  dateIcon: "glyphicon glyphicon-calendar",
+  // Computed options
+  minDate: datetimepickerDefaultConfig['minDate'],
+  maxDate: datetimepickerDefaultConfig['maxDate'],
+  disabledDates: [],
+  enabledDates: [],
+  dateIcon: 'glyphicon glyphicon-calendar',
 
-  disabled:false,
+  disabled: false,
   open: false,
   forceDateOutput: false,
 
@@ -32,171 +31,161 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     var target;
     var self = this;
     if (this.get('noIcon')) {
-      var targetClassNames = '.'+ this.get('textFieldClassNames').join('.');
+      var targetClassNames = '.' + this.get('textFieldClassNames').join('.');
       target = this.$(targetClassNames);
     } else {
       target = this.$();
     }
     var bsDateTimePicker = target.datetimepicker(this._buildConfig());
-    var bsDateTimePickerFn = bsDateTimePicker.data("DateTimePicker");
+    var bsDateTimePickerFn = bsDateTimePicker.data('DateTimePicker');
 
     this.set('bsDateTimePicker', bsDateTimePickerFn);
-    if(self.get("date") === undefined) {
+    if (self.get('date') === undefined) {
       bsDateTimePickerFn.date(null);
     } else {
-      bsDateTimePickerFn.date(self.get("date"));
+      bsDateTimePickerFn.date(self.get('date'));
     }
 
-
-    bsDateTimePicker.on("dp.change", function(ev) {
-      if(Ember.isNone(ev.date)) {
-        self.set("date", undefined);
+    bsDateTimePicker.on('dp.change', function(ev) {
+      if (Ember.isNone(ev.date)) {
+        self.set('date', undefined);
       } else if (!ev.date.isSame(self.get('date'))) {
-        if(self.forceDateOutput) {
-          self.set("date", ev.date.toDate());
+        if (self.forceDateOutput) {
+          self.set('date', ev.date.toDate());
         } else {
-          self.set("date", ev.date);
+          self.set('date', ev.date);
         }
       }
     });
 
     this._disabledObserver();
 
-    if(self.get("open")) {
-      self.get("bsDateTimePicker").show();
+    if (self.get('open')) {
+      self.get('bsDateTimePicker').show();
     }
   }),
 
-
-
   _disabledObserver: Ember.observer('disabled', function() {
-    if(this.get("disabled")) {
-      this.get("bsDateTimePicker").disable();
+    if (this.get('disabled')) {
+      this.get('bsDateTimePicker').disable();
     } else {
-      this.get("bsDateTimePicker").enable();
+      this.get('bsDateTimePicker').enable();
     }
   }),
 
   _openObserver: Ember.observer('open', function() {
-    if(this.get("open")) {
-      this.get("bsDateTimePicker").show();
+    if (this.get('open')) {
+      this.get('bsDateTimePicker').show();
     } else {
-      this.get("bsDateTimePicker").hide();
+      this.get('bsDateTimePicker').hide();
     }
   }),
 
   _minDateObserver: Ember.observer('minDate', function() {
-    if(Ember.isNone(this.get('minDate'))) {
-      this.get("bsDateTimePicker").minDate(false);
+    if (Ember.isNone(this.get('minDate'))) {
+      this.get('bsDateTimePicker').minDate(false);
     } else {
-      this.get("bsDateTimePicker").minDate(this.get('minDate'));
+      this.get('bsDateTimePicker').minDate(this.get('minDate'));
     }
   }),
 
   _maxDateObserver: Ember.observer('maxDate', function() {
-    if(Ember.isNone(this.get('maxDate'))) {
-      this.get("bsDateTimePicker").maxDate(false);
+    if (Ember.isNone(this.get('maxDate'))) {
+      this.get('bsDateTimePicker').maxDate(false);
     } else {
-      this.get("bsDateTimePicker").maxDate(this.get('maxDate'));
+      this.get('bsDateTimePicker').maxDate(this.get('maxDate'));
     }
   }),
 
   _disabledDatesObserver: Ember.observer('disabledDates', function() {
-    this.get("bsDateTimePicker").disabledDates(this.get('disabledDates'));
+    this.get('bsDateTimePicker').disabledDates(this.get('disabledDates'));
   }),
 
   _enabledDatesObserver: Ember.observer('enabledDates', function() {
-    this.get("bsDateTimePicker").enabledDates(this.get('enabledDates'));
+    this.get('bsDateTimePicker').enabledDates(this.get('enabledDates'));
   }),
 
   _dateObserver: Ember.observer('date', function() {
-    var bsDateTimePickerFn = this.get("bsDateTimePicker");
+    var bsDateTimePickerFn = this.get('bsDateTimePicker');
 
-    if(this.get("date") === undefined) {
+    if (this.get('date') === undefined) {
       bsDateTimePickerFn.date(null);
     } else {
-      bsDateTimePickerFn.date(this.get("date"));
+      bsDateTimePickerFn.date(this.get('date'));
     }
 
   }),
 
   _destroyDatepicker: Ember.on('willDestroyElement', function() {
-    this.get("bsDateTimePicker").destroy();
+    this.get('bsDateTimePicker').destroy();
   }),
 
   _buildConfig: function() {
     var config = {};
-    for(var i=0; i< isDatetimepickerConfigKeys.length; i++) {
+    for (var i = 0; i < isDatetimepickerConfigKeys.length; i++) {
       config[isDatetimepickerConfigKeys[i]] = this.get(isDatetimepickerConfigKeys[i]);
     }
+
     return config;
   },
 
   inputGroupClass: Ember.computed(function() {
-    if(!this.get('noIcon')) {
+    if (!this.get('noIcon')) {
       return 'input-group';
     }
-
   }),
 
   /**
-
     Exposing the textField properties.
-    Every property beginning with "textField" will be exposed to the TextField view.
+    Every property beginning with 'textField' will be exposed to the TextField view.
 
     ```handlebars
-    {{bs-datetimepicker textFieldPlaceholder="Date"}}
+    {{bs-datetimepicker textFieldPlaceholder='Date'}}
     ```
-    "textFieldPlaceholder" will be exposed to the TextField as "placeholder" property.
-
+    'textFieldPlaceholder' will be exposed to the TextField as 'placeholder' property.
   */
-  setUnknownProperty: function(key, value){
+  setUnknownProperty: function(key, value) {
     var prop;
     var ckey;
-    if(key.indexOf("textField") === 0) {
 
-      if(Ember.isNone(this.get('textFieldOptions'))) {
-        this.set('textFieldOptions',{});
+    if (key.indexOf('textField') === 0) {
+      if (Ember.isNone(this.get('textFieldOptions'))) {
+        this.set('textFieldOptions', {});
       }
 
-      if(Ember.IS_BINDING.test(key)) {
-        prop = key.substring(0,key.length-7);
-      }
-      else {
-       prop = key.substring(0,key.length);
+      if (Ember.IS_BINDING.test(key)) {
+        prop = key.substring(0, key.length-7);
+      } else {
+        prop = key.substring(0, key.length);
       }
 
       ckey = prop.substring(9);
       ckey = ckey.charAt(0).toLowerCase() + ckey.substr(1);
 
-      if(Ember.isNone(this.get('textFieldOptions.'+prop))) {
+      if (Ember.isNone(this.get('textFieldOptions.' + prop))) {
 
-        this.set('textFieldOptions.'+prop,ckey);
+        this.set('textFieldOptions.' + prop, ckey);
 
         Ember.defineProperty(this, prop, null, value);
       }
-    }
-    else {
-      if(Ember.platform.hasPropertyAccessors) {
+    } else {
+      if (Ember.platform.hasPropertyAccessors) {
         Ember.defineProperty(this, key, null, value);
-      }
-      else {
+      } else {
         this[key] = value;
       }
     }
   }
 });
 
-
-var computedProps = Ember.A(["minDate","maxDate","disabledDates","enabledDates","dateIcon"]);
+var computedProps = Ember.A(['minDate', 'maxDate', 'disabledDates', 'enabledDates', 'dateIcon']);
 var newClassConfig = {};
-for(var i=0; i<isDatetimepickerConfigKeys.length; i++) {
-  if(!computedProps.contains(isDatetimepickerConfigKeys[i])) {
+for (var i = 0; i < isDatetimepickerConfigKeys.length; i++) {
+  if (!computedProps.contains(isDatetimepickerConfigKeys[i])) {
     newClassConfig[isDatetimepickerConfigKeys[i]] = datetimepickerDefaultConfig[isDatetimepickerConfigKeys[i]];
   }
 }
 
 bsDateTimePickerComponent.reopen(newClassConfig);
-
 
 export default bsDateTimePickerComponent;

--- a/addon/mixins/datetimepicker_textfield.js
+++ b/addon/mixins/datetimepicker_textfield.js
@@ -1,19 +1,18 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-
   /**
     Pick up exposed properties from parentView.textFieldOptions and bound them to this instance
-
   */
-  _initDateTimePickerTextField: Ember.on('init',function() {
+  _initDateTimePickerTextField: Ember.on('init', function() {
     var self = this;
-    var options = this.get("parentView.textFieldOptions");
-    this.set('classNames', this.get("parentView.textFieldClassNames"));
-    if(!Ember.isEmpty(options)) {
-      Ember.keys(options).forEach(function(key) {
-        Ember.defineProperty(self, options[key], Ember.computed("parentView."+key, function(){
-          return self.get("parentView."+key);
+    var options = this.get('parentView.textFieldOptions');
+    this.set('classNames', this.get('parentView.textFieldClassNames'));
+
+    if (!Ember.isEmpty(options)) {
+      Object.keys(options).forEach(function(key) {
+        Ember.defineProperty(self, options[key], Ember.computed('parentView.' + key, function() {
+          return self.get('parentView.' + key);
         }));
       });
     }

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,4 +1,4 @@
-{{#if template}}
+{{#if hasBlock}}
   {{yield}}
 {{else}}
   {{view textFieldClass disabled=disabled name=textFieldName}}


### PR DESCRIPTION
Addresses #36.

There are no more deprecations left, except in `ember-cli` because of using `view`. That requires much more changes.

For the new version, keep in mind that `hasBlock` is `1.13+` only, therefore is a braking change.