### PR TITLE
Fix ember-cli-moment-shim to 0.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "qunit": "~1.17.1",
     "bootstrap": "~3.3.2",
     "moment": "~2.10.3",
-    "ember-cli-moment-shim": "~0.2.0",
+    "ember-cli-moment-shim": "0.2.0",
     "eonasdan-bootstrap-datetimepicker": "~4.14.30"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-cli-moment-shim 0.3.x changes the behavior to be an addon and is no longer a bower dep instead should be an npm dep.  Also, the app.imports are no longer required.