### PR TITLE
Remove a usage of the `view` helper from the hbs template

### DIFF
--- a/addon/components/bs-datetimepicker-input.js
+++ b/addon/components/bs-datetimepicker-input.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import DateTimePickerTextFieldMixin from 'ember-bootstrap-datetimepicker/mixins/datetimepicker_textfield';
+
+var BsDatetimepickerInputComponent = Ember.TextField.extend(DateTimePickerTextFieldMixin);
+
+export default BsDatetimepickerInputComponent;

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import DateTimePickerTextFieldMixin from 'ember-bootstrap-datetimepicker/mixins/datetimepicker_textfield';
 
 var computed = Ember.computed;
 var datetimepickerDefaultConfig = Ember.$.fn.datetimepicker.defaults;
@@ -9,7 +8,6 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   concatenatedProperties: ['textFieldClassNames'],
   classNames: ['date'],
   classNameBindings: ['inputGroupClass'],
-  textFieldClass: Ember.TextField.extend(DateTimePickerTextFieldMixin),
   textFieldClassNames: ['form-control'],
   textFieldName: computed.alias('elementId'),
   textFieldOptions: null,

--- a/app/components/bs-datetimepicker-input.js
+++ b/app/components/bs-datetimepicker-input.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-datetimepicker/components/bs-datetimepicker-input';

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,7 +1,7 @@
 {{#if hasBlock}}
   {{yield}}
 {{else}}
-  {{view textFieldClass disabled=disabled name=textFieldName}}
+  {{bs-datetimepicker-input disabled=disabled name=textFieldName}}
 {{/if}}
 {{#unless noIcon}}
 <span class="input-group-addon">

--- a/tests/unit/misc-test.js
+++ b/tests/unit/misc-test.js
@@ -15,7 +15,8 @@ moduleForComponent('bs-datetimepicker', 'ember-bootstrap-datetimepicker unit', {
       Ember.run(component, 'destroy');
       component = null;
     }
-  }
+  },
+  needs: ['component:bs-datetimepicker-input']
 });
 
 


### PR DESCRIPTION
Ember 2 will deprecate the `view` helper (http://emberjs.com/deprecations/v1.x/#toc_view-and-controller-template-keywords). The first two betas already did this. Ember 2 beta 3 goes further and drops it altogether. This makes the ember-bootstrap-datetimepicker incompatible with the latest versions of Ember 2 beta.

I've put together something that seems to work in Ember 2. I haven't tested it with Ember 1.x, though. The downside is that it changes the interface of the bs-datetimepicker component (it drops the `textFieldClass`). I haven't found it mentioned anywhere in the documentation so I assumed it is a private API and it's ok to change it.