### PR TITLE
Ember 2 compatibility

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -114,7 +114,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     for (var i = 0; i < isDatetimepickerConfigKeys.length; i++) {
       configKey = isDatetimepickerConfigKeys[i];
       if (!computedProps.contains(configKey)) {
-        config[configKey] = this.getWithDefault('attrs.'+configKey, datetimepickerDefaultConfig[configKey]);
+        config[configKey] = this.getWithDefault(configKey, datetimepickerDefaultConfig[configKey]);
       }
     }
 

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -110,11 +110,11 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     var datetimepickerDefaultConfig = Ember.$.fn.datetimepicker.defaults;
     var isDatetimepickerConfigKeys = Object.keys(datetimepickerDefaultConfig);
     var config = {};
+    var configKey;
     for (var i = 0; i < isDatetimepickerConfigKeys.length; i++) {
-      if (!computedProps.contains(isDatetimepickerConfigKeys[i])) {
-        config[isDatetimepickerConfigKeys[i]] = this.getWithDefault(
-          'attrs.'+isDatetimepickerConfigKeys[i],
-          datetimepickerDefaultConfig[isDatetimepickerConfigKeys[i]]);
+      configKey = isDatetimepickerConfigKeys[i];
+      if (!computedProps.contains(configKey)) {
+        config[configKey] = this.getWithDefault('attrs.'+configKey, datetimepickerDefaultConfig[configKey]);
       }
     }
 

--- a/tests/integration/misc-test.js
+++ b/tests/integration/misc-test.js
@@ -89,3 +89,12 @@ test("test the showClear option", function(assert) {
     assert.equal(date, undefined, 'should be undefined after clear the date');
   });
 });
+
+test("test that non-computed properties are passed to the bootstrap-datetimepicker", function(assert) {
+  assert.expect(1);
+
+  this.set('localeName', 'en-IE');
+  this.render(hbs`{{bs-datetimepicker locale=localeName}}`);
+
+  assert.equal(this.$().length, 1);
+});


### PR DESCRIPTION
I am experiencing some problems with Ember 2. I tried setting the `locale` property and I got an error. It works correctly only for literal values. It fails otherwise (the test in the PR will fail without the rest of the changes). I traced it to this piece of code in `bs-datetimepicker.js`:

```javascript
config[isDatetimepickerConfigKeys[i]] = this.getWithDefault(
  'attrs.'+isDatetimepickerConfigKeys[i],
  datetimepickerDefaultConfig[isDatetimepickerConfigKeys[i]]);
```

When accessing `attrs.locale` Ember returns a `MUTABLE_CELL` object. Its value is something like `{"value": "en-US", ...}` instead of just `"en-US"`. This results in an error in moment.js. Using just `locale` instead of `attrs.locale` seems to return the correct thing.

I am assuming this is done intentionally because of something in Ember 1. So I don't expect this to get merged as it is.