### PR TITLE
Support Readonly attribute

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -117,6 +117,8 @@ var bsDateTimePickerComponent = Ember.Component.extend({
           datetimepickerDefaultConfig[isDatetimepickerConfigKeys[i]]);
       }
     }
+    
+    config.ignoreReadonly = true;
 
     return config;
   }

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,7 +1,7 @@
 {{#if hasBlock}}
   {{yield}}
 {{else}}
-  {{input type="text" class="form-control" disabled=disabled name=textFieldName}}
+  {{input type="text" class="form-control" disabled=disabled name=textFieldName readonly=readonly}}
 {{/if}}
 {{#unless noIcon}}
 <span class="input-group-addon">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -8,6 +8,7 @@
           <li><a href="#example4">Font-Awesome Icons</a></li>
           <li><a href="#example5">Template Block</a></li>
           <li><a href="#example6">No Icon</a></li>
+          <li><a href="#example7">Readonly</a></li>
       </ul>
     </div>
   </div>
@@ -197,6 +198,25 @@
         <p>
           <pre>&lt;p&gt;
   \{{bs-datetimepicker date=model.date2 noIcon=true}}
+&lt;/p&gt;
+        </pre>
+        </p>
+      </div>
+    </div>
+
+
+
+    <div id="example7">
+      <a name="example7"></a>
+      <h3>Readonly</h3>
+      <div>
+        <p class="noicon">
+          {{bs-datetimepicker date=model.date2 readonly=true noIcon=true}}
+        </p>
+        <h5>Code</h5>
+        <p>
+          <pre>&lt;p&gt;
+  \{{bs-datetimepicker date=model.date2 readonly=true noIcon=true}}
 &lt;/p&gt;
         </pre>
         </p>


### PR DESCRIPTION
ignoreReadonly's default value is false. So one has to set `<input readonly = "true"` _and_ `ignoreReadonly = true` for the desired behavior. That is why I set ignoreReadonly's default value to true in `_buildConfig`.
