### PR TITLE
Detecting the consumer of the addon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ var path = require('path');
 module.exports = {
   name: 'ember-bootstrap-datetimepicker',
 
-  included: function(app) {
-    this._super.included(app);
+  included: function(target) {
+    this._super.included.apply(this, arguments);
 
+    var app           = target.app || target;
     var bowerDir      = app.bowerDirectory;
     var bootstrapPath = path.join(bowerDir,'/bootstrap/dist/');
     var options       = app.options['ember-bootstrap-datetimepicker'] || {};


### PR DESCRIPTION
I'm working on a composed addon for my team using `ember-bootstrap-datetimepicker`. As part of this, I moved the `ember-bootstrap-datetimepicker` from my `devDependencies` to `dependencies` in `package.json`. This changes the way that `app` is accessed slightly in the addon entry file.