### PR TITLE
add support for the inline option

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -12,15 +12,15 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   dateIcon: 'glyphicon glyphicon-calendar',
   placeholder: '',
 
-  inputGroupClass: computed('attrs.noIcon', function() {
-    if (!this.getAttr('noIcon')) {
-       return 'input-group';
-     }
+  inputGroupClass: computed('attrs.{noIcon,inline}', function() {
+    if (!this.getAttr('noIcon') && !this.getAttr('inline')) {
+      return 'input-group';
+    }
   }),
 
   _initDatepicker: on('didInsertElement', function() {
     var target;
-    if (this.getAttr('noIcon')) {
+    if (this.getAttr('noIcon') && !this.getAttr('inline')) {
       target = this.$('.' + this.get('textFieldClassNames').join('.'));
     } else {
       target = this.$();
@@ -32,7 +32,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
 
     bsDateTimePicker.on('dp.change', ev => {
       run(() => {
-        if(this.attrs.updateDate) {
+        if (this.attrs.updateDate) {
           if (Ember.isNone(ev.date) || ev.date === false) {
             this.sendAction('updateDate', undefined);
           } else if (!ev.date.isSame(this.getAttr('date'))) {
@@ -63,7 +63,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
   _updateDateTimePicker() {
 
     var dateTimePicker = this.get('bsDateTimePicker');
-    if(dateTimePicker) {
+    if (dateTimePicker) {
       if (this.getAttr('disabled')) {
         dateTimePicker.disable();
       } else {

--- a/app/templates/components/bs-datetimepicker.hbs
+++ b/app/templates/components/bs-datetimepicker.hbs
@@ -1,10 +1,12 @@
-{{#if hasBlock}}
-  {{yield}}
-{{else}}
-  {{input type="text" class="form-control" disabled=disabled name=textFieldName placeholder=placeholder}}
-{{/if}}
-{{#unless noIcon}}
-<span class="input-group-addon">
-  <span class="{{dateIcon}}"></span>
-</span>
+{{#unless inline}}
+  {{#if hasBlock}}
+    {{yield}}
+  {{else}}
+    {{input type="text" class="form-control" disabled=disabled name=textFieldName placeholder=placeholder}}
+  {{/if}}
+  {{#unless noIcon}}
+      <span class="input-group-addon">
+        <span class="{{dateIcon}}"></span>
+      </span>
+  {{/unless}}
 {{/unless}}

--- a/tests/integration/misc-test.js
+++ b/tests/integration/misc-test.js
@@ -106,3 +106,15 @@ test("test placeholder support", function(assert) {
 
   assert.equal(this.$('input').attr('placeholder'), 'test-placeholder');
 });
+
+test("test the inline option", function(assert) {
+  assert.expect(2);
+
+  assert.equal($(".bootstrap-datetimepicker-widget").length, 0, "no date picker before render");
+
+  this.render(hbs`{{bs-datetimepicker inline=true}}`);
+
+  andThen(() => {
+    assert.equal($(".bootstrap-datetimepicker-widget").css("display"), "block", "date picker is displayed after first render");
+  });
+});


### PR DESCRIPTION
I removed everything from the template if `inline=true` is set, like in the [example in the docs](http://eonasdan.github.io/bootstrap-datetimepicker/#inline).
