### PR TITLE
Setup change event after render

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -30,6 +30,20 @@ var bsDateTimePickerComponent = Ember.Component.extend({
 
     this.set('bsDateTimePicker', bsDateTimePickerFn);
 
+    run.scheduleOnce('afterRender', this, this._setupChangeEvent, bsDateTimePicker);
+
+    this._updateDateTimePicker();
+
+    if (this.attrs.open) {
+      this.get('bsDateTimePicker').show();
+    }
+  }),
+
+  didReceiveAttrs() {
+    this._updateDateTimePicker();
+  },
+  
+  _setupChangeEvent(bsDateTimePicker) {
     bsDateTimePicker.on('dp.change', ev => {
       run(() => {
         if(this.attrs.updateDate) {
@@ -48,16 +62,6 @@ var bsDateTimePickerComponent = Ember.Component.extend({
         }
       });
     });
-
-    this._updateDateTimePicker();
-
-    if (this.attrs.open) {
-      this.get('bsDateTimePicker').show();
-    }
-  }),
-
-  didReceiveAttrs() {
-    this._updateDateTimePicker();
   },
 
   _updateDateTimePicker() {


### PR DESCRIPTION
```hbs
{{bs-datetimepicker date=endDate updateDate=(action 'endDateChanged')}}
```

Currently the `updateDate` action gets called on `didInsertElement` which triggers the following deprecation: 

```
You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation. [deprecation id: ember-views.dispatching-modify-property]
```

Moving the change event setup also prevents a user from changing a property during render which has even caused me a `Maximum call stack size exceeded` error.

Ping @jasonmit 