### PR TITLE
Remove bootstrap dependency

### DIFF
--- a/blueprints/ember-bootstrap-datetimepicker/index.js
+++ b/blueprints/ember-bootstrap-datetimepicker/index.js
@@ -3,7 +3,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addAddonToProject('ember-cli-moment-shim', '~0.6.1').then(function() {
-      return this.addPackageToProject('eonasdan-bootstrap-datetimepicker', '~4.14.30');
+      return this.addPackageToProject('eonasdan-bootstrap-datetimepicker', '~4.15.35');
     }.bind(this));
   }
 };

--- a/index.js
+++ b/index.js
@@ -56,8 +56,6 @@ module.exports = {
 
   treeForVendor: function(vendorTree) {
     var trees = [];
-    var bootstrapPath = require.resolve('bootstrap')
-          .replace(path.join('js', 'npm.js'), '');
     var datetimepickerPath = require.resolve('eonasdan-bootstrap-datetimepicker')
           .replace(path.join('src', 'js', 'bootstrap-datetimepicker.js'), '');
 
@@ -65,9 +63,13 @@ module.exports = {
       trees.push(vendorTree);
     }
 
-    trees.push(new Funnel(bootstrapPath, {
-      destDir: 'bootstrap'
-    }));
+    try {
+      var bootstrapPath = require.resolve('bootstrap')
+            .replace(path.join('js', 'npm.js'), '');
+      trees.push(new Funnel(bootstrapPath, {
+        destDir: 'bootstrap'
+      }));
+    } catch(err) {}
 
     trees.push(new Funnel(datetimepickerPath, {
       destDir: 'eonasdan-bootstrap-datetimepicker'


### PR DESCRIPTION
Currently you are forcing all users of this addon to have `bootstrap` as an npm dependency. This removes that restriction.