### PR TITLE
Fix `contains` deprecation warning after Ember 2.8 upgrade.

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -117,7 +117,7 @@ var bsDateTimePickerComponent = Ember.Component.extend({
     var configKey;
     for (var i = 0; i < isDatetimepickerConfigKeys.length; i++) {
       configKey = isDatetimepickerConfigKeys[i];
-      if (!computedProps.contains(configKey)) {
+      if (!computedProps.includes(configKey)) {
         config[configKey] = this.getWithDefault(configKey, datetimepickerDefaultConfig[configKey]);
       }
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Fix https://github.com/plusacht/ember-bootstrap-datetimepicker/issues/84

There was one `Enumerable#contains` that I [changed to `includes`](http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains) and added the polyfill in order to maintain backwards compatibility.
