### PR TITLE
Added dynamic attributes so they are not filtered to the component

### DIFF
--- a/addon/-private/dynamic-attribute-bindings.js
+++ b/addon/-private/dynamic-attribute-bindings.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+const { Mixin, set } = Ember;
+
+export default Mixin.create({
+  NON_ATTRIBUTE_BOUND_PROPS: ['class', 'classNames'],
+  concatenatedProperties: ['NON_ATTRIBUTE_BOUND_PROPS'],
+  init() {
+    this._super(...arguments);
+
+    let newAttributeBindings = [];
+    for (let key in this.attrs) {
+      if (this.NON_ATTRIBUTE_BOUND_PROPS.indexOf(key) === -1 && this.attributeBindings.indexOf(key) === -1) {
+        newAttributeBindings.push(key);
+      }
+    }
+
+    set(this, 'attributeBindings', this.attributeBindings.concat(newAttributeBindings));
+  }
+});

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
+import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 const { computed, run } = Ember;
 const computedProps = Ember.A(['minDate', 'maxDate', 'disabledDates', 'enabledDates', 'dateIcon', 'placeholder']);
 
-var bsDateTimePickerComponent = Ember.Component.extend({
+var bsDateTimePickerComponent = Ember.Component.extend(DynamicAttributeBindings, {
+  attributeBindings: [],
   concatenatedProperties: ['textFieldClassNames'],
   classNames: ['date'],
   classNameBindings: ['inputGroupClass'],


### PR DESCRIPTION
If you want to use attributeBindings to for example add a custom validation with ember-cp-validations and maybe bootstrap popups, you need to add a data-toggle attribute which is currently stripped out.

I've found that the one-way-controls component solves this in a neat way and they seem OK with being used by other addons: https://github.com/DockYard/ember-one-way-controls/issues/132