### PR TITLE
Fix ember-cli-babel deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.4.0",
-    "ember-cli-babel": "^6.6.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.9",
@@ -47,6 +46,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
+    "ember-cli-babel": "^6.6.0",
     "ember-runtime-enumerable-includes-polyfill": "^2.1.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.4.0",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.9",
@@ -46,8 +47,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "ember-cli-babel": "^5.0.0",
-    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
+    "ember-runtime-enumerable-includes-polyfill": "^2.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: project -> ember-bootstrap-datetimepicker -> -> ember-cli-babel 

Fixes #94 